### PR TITLE
Use proper datatypes in for loops

### DIFF
--- a/src/ST_CRC.h
+++ b/src/ST_CRC.h
@@ -24,7 +24,7 @@ public: // <<---------------------------------------//public
 
 	void generateTable()
 	{
-		for (int i = 0; i < tableLen_; ++i)
+		for (uint16_t i = 0; i < tableLen_; ++i)
 		{
 			int curr = i;
 
@@ -42,7 +42,7 @@ public: // <<---------------------------------------//public
 
 	void printTable()
 	{
-		for (int i = 0; i < tableLen_; i++)
+		for (uint16_t i = 0; i < tableLen_; ++i)
 		{
 			Serial.print(csTable[i], HEX);
 
@@ -64,7 +64,7 @@ public: // <<---------------------------------------//public
 	{
 		uint8_t crc = 0;
 
-		for (uint16_t i = 0; i < len; i++)
+		for (uint16_t i = 0; i < len; ++i)
 			crc = csTable[crc ^ arr[i]];
 
 		return crc;


### PR DESCRIPTION
This is to get rid of these warnings during compilation:

```
/root/Arduino/libraries/SerialTransfer/src/ST_CRC.h: In member function 'void SerialTransferCRC::generateTable()':
/root/Arduino/libraries/SerialTransfer/src/ST_CRC.h:27:21: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   for (int i = 0; i < tableLen_; ++i)
                   ~~^~~~~~~~~~~
/root/Arduino/libraries/SerialTransfer/src/ST_CRC.h: In member function 'void SerialTransferCRC::printTable()':
/root/Arduino/libraries/SerialTransfer/src/ST_CRC.h:45:21: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   for (int i = 0; i < tableLen_; i++)
```