### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,16 +48,24 @@ myTransfer.begin(Serial1);
 
 
 # *Transmitting Arduino:*
-1.) Insert data bytes into the SerialTransfer TX buffer:
+1.) Insert data bytes into the SerialTransfer TX buffer manually and/or automatically using `myTransfer.txObj()`:
 ```c++
+// use this variable to keep track of how many
+// bytes we're stuffing in the transmit buffer
+uint16_t sendSize = 0;
+
+///////////////////////////////////////// Stuff buffer with individual bytes
 myTransfer.txBuff[0] = 'h';
-myTransfer.txBuff[1] = 'i';
-myTransfer.txBuff[2] = '\n';
+myTransfer.txBuff[1] = 200;
+sendSize += 2;
+
+///////////////////////////////////////// Stuff buffer with struct
+sendSize = myTransfer.txObj(testStruct, sendSize);
 ```
 
-2.) Transmit the data via the "sendData" member function. The argument of sendData() is the number of bytes of the TX buffer to be transmitted. Since we stuffed 3 data bytes ('h', 'i', and '\n') into the TX buffer, we need to specify 3 bytes to be transferred:
+2.) Transmit the data via the "sendData" member function. The argument of sendData() is the number of bytes of the TX buffer to be transmitted. Since we stuffed 3 data bytes ('h', 'i', and '\n') plus the total number of bytes in `testStruct` into the TX buffer, we need to specify `sendSize` bytes to be transferred:
 ```c++
-myTransfer.sendData(3);
+myTransfer.sendData(sendSize);
 ```
 
 # *Complete TX Code:*
@@ -66,20 +74,36 @@ myTransfer.sendData(3);
 
 SerialTransfer myTransfer;
 
+struct STRUCT {
+  char z;
+  float y;
+} testStruct;
+
 void setup()
 {
   Serial.begin(115200);
   Serial1.begin(115200);
   myTransfer.begin(Serial1);
+  
+  testStruct.z = '|';
+  testStruct.y = 4.5;
 }
 
 void loop()
 {
+  // use this variable to keep track of how many
+  // bytes we're stuffing in the transmit buffer
+  uint16_t sendSize = 0;
+
+  ///////////////////////////////////////// Stuff buffer with individual bytes
   myTransfer.txBuff[0] = 'h';
-  myTransfer.txBuff[1] = 'i';
-  myTransfer.txBuff[2] = '\n';
+  myTransfer.txBuff[1] = 200;
+  sendSize += 2;
+
+  ///////////////////////////////////////// Stuff buffer with struct
+  sendSize = myTransfer.txObj(testStruct, sendSize);
   
-  myTransfer.sendData(3);
+  myTransfer.sendData(sendSize);
   delay(100);
 }
 ```
@@ -105,12 +129,19 @@ else if(myTransfer.status < 0)
 }
 ```
 
-2.) If a full packet has been received, use the SerialTransfer class's RX buffer to access the received data bytes:
+2.) If a full packet has been received, use the SerialTransfer class's RX buffer to manually (using `myTransfer.bytesRead`) and/or automatically (using `myTransfer.rxObj()`) access the received data bytes:
 ```c++
-Serial.println("New Data");
-for(byte i = 0; i < myTransfer.bytesRead; i++)
-  Serial.write(myTransfer.rxBuff[i]);
-Serial.println();
+// use this variable to keep track of how many
+// bytes we've processed from the receive buffer
+uint16_t recSize = 0;
+
+///////////////////////////////////////// Manually read the first two bytes in the rxBuff
+myTransfer.rxBuff[0];
+myTransfer.rxBuff[1];
+recSize += 2;
+
+///////////////////////////////////////// Automatically read the struct's bytes in the rxBuff
+recSize = myTransfer.rxObj(testStruct, recSize);
 ```
 
 # *Complete RX Code:*
@@ -118,6 +149,11 @@ Serial.println();
 #include "SerialTransfer.h"
 
 SerialTransfer myTransfer;
+
+struct STRUCT {
+  char z;
+  float y;
+} testStruct;
 
 void setup()
 {
@@ -130,10 +166,22 @@ void loop()
 {
   if(myTransfer.available())
   {
-    Serial.println("New Data");
-    for(byte i = 0; i < myTransfer.bytesRead; i++)
-      Serial.write(myTransfer.rxBuff[i]);
-    Serial.println();
+    // use this variable to keep track of how many
+    // bytes we've processed from the receive buffer
+    uint16_t recSize = 0;
+
+    ///////////////////////////////////////// Manually read the first two bytes in the rxBuff
+    Serial.print(myTransfer.rxBuff[0]);
+    Serial.print(' ');
+    Serial.print(myTransfer.rxBuff[1]);
+    Serial.print(" | ");
+    recSize += 2;
+
+    ///////////////////////////////////////// Automatically read the struct's bytes in the rxBuff
+    recSize = myTransfer.rxObj(testStruct, recSize);
+    Serial.print(testStruct.z);
+    Serial.print(' ');
+    Serial.println(testStruct.y);
   }
   else if(myTransfer.status < 0)
   {

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ void loop()
     uint16_t recSize = 0;
 
     ///////////////////////////////////////// Manually read the first two bytes in the rxBuff
-    Serial.print(myTransfer.rxBuff[0]);
+    Serial.print((char)myTransfer.rxBuff[0]);
     Serial.print(' ');
     Serial.print(myTransfer.rxBuff[1]);
     Serial.print(" | ");

--- a/examples/full_duplex_multiple_objects/full_duplex_multiple_objects.ino
+++ b/examples/full_duplex_multiple_objects/full_duplex_multiple_objects.ino
@@ -34,12 +34,10 @@ void loop()
   sendSize += 2;
 
   ///////////////////////////////////////// Stuff buffer with struct
-  myTransfer.txObj(testStruct, sizeof(testStruct), sendSize);
-  sendSize += sizeof(testStruct);
+  sendSize = myTransfer.txObj(testStruct, sendSize);
 
   ///////////////////////////////////////// Stuff buffer with array
-  myTransfer.txObj(arr, sizeof(arr), sendSize);
-  sendSize += sizeof(arr);
+  sendSize = myTransfer.txObj(arr, sendSize);
 
   ///////////////////////////////////////// Send buffer
   myTransfer.sendData(sendSize);
@@ -70,4 +68,3 @@ void loop()
       Serial.println(F("STOP_BYTE_ERROR"));
   }
 }
-

--- a/examples/rx_multiple_objects/rx_multiple_objects.ino
+++ b/examples/rx_multiple_objects/rx_multiple_objects.ino
@@ -33,14 +33,13 @@ void loop()
     Serial.print(" | ");
     recSize += 2;
 
-    myTransfer.rxObj(testStruct, sizeof(testStruct), recSize);
+    recSize = myTransfer.rxObj(testStruct, recSize);
     Serial.print(testStruct.z);
     Serial.print(' ');
     Serial.print(testStruct.y);
     Serial.print(" | ");
-    recSize += sizeof(testStruct);
 
-    myTransfer.rxObj(arr, sizeof(arr), recSize);
+    recSize = myTransfer.rxObj(arr, recSize);
     Serial.print(arr[0]);
     Serial.print(' ');
     Serial.print(arr[1]);

--- a/examples/softwareserial_full_duplex_multiple_objects/softwareserial_full_duplex_multiple_objects.ino
+++ b/examples/softwareserial_full_duplex_multiple_objects/softwareserial_full_duplex_multiple_objects.ino
@@ -37,12 +37,10 @@ void loop()
   sendSize += 2;
 
   ///////////////////////////////////////// Stuff buffer with struct
-  myTransfer.txObj(testStruct, sizeof(testStruct), sendSize);
-  sendSize += sizeof(testStruct);
+  sendSize = myTransfer.txObj(testStruct, sendSize);
 
   ///////////////////////////////////////// Stuff buffer with array
-  myTransfer.txObj(arr, sizeof(arr), sendSize);
-  sendSize += sizeof(arr);
+  sendSize = myTransfer.txObj(arr, sendSize);
 
   ///////////////////////////////////////// Send buffer
   myTransfer.sendData(sendSize);

--- a/examples/softwareserial_rx_multiple_objects/softwareserial_rx_multiple_objects.ino
+++ b/examples/softwareserial_rx_multiple_objects/softwareserial_rx_multiple_objects.ino
@@ -36,14 +36,13 @@ void loop()
     Serial.print(" | ");
     recSize += 2;
 
-    myTransfer.rxObj(testStruct, sizeof(testStruct), recSize);
+    recSize = myTransfer.rxObj(testStruct, recSize);
     Serial.print(testStruct.z);
     Serial.print(' ');
     Serial.print(testStruct.y);
     Serial.print(" | ");
-    recSize += sizeof(testStruct);
 
-    myTransfer.rxObj(arr, sizeof(arr), recSize);
+    recSize = myTransfer.rxObj(arr, recSize);
     Serial.print(arr[0]);
     Serial.print(' ');
     Serial.print(arr[1]);

--- a/examples/softwareserial_tx_multiple_objects/softwareserial_tx_multiple_objects.ino
+++ b/examples/softwareserial_tx_multiple_objects/softwareserial_tx_multiple_objects.ino
@@ -37,12 +37,10 @@ void loop()
   sendSize += 2;
 
   ///////////////////////////////////////// Stuff buffer with struct
-  myTransfer.txObj(testStruct, sizeof(testStruct), sendSize);
-  sendSize += sizeof(testStruct);
+  sendSize = myTransfer.txObj(testStruct, sendSize);
 
   ///////////////////////////////////////// Stuff buffer with array
-  myTransfer.txObj(arr, sizeof(arr), sendSize);
-  sendSize += sizeof(arr);
+  sendSize = myTransfer.txObj(arr, sendSize);
 
   ///////////////////////////////////////// Send buffer
   myTransfer.sendData(sendSize);

--- a/examples/tx_multiple_objects/tx_multiple_objects.ino
+++ b/examples/tx_multiple_objects/tx_multiple_objects.ino
@@ -34,12 +34,10 @@ void loop()
   sendSize += 2;
 
   ///////////////////////////////////////// Stuff buffer with struct
-  myTransfer.txObj(testStruct, sizeof(testStruct), sendSize);
-  sendSize += sizeof(testStruct);
+  sendSize = myTransfer.txObj(testStruct, sendSize);
 
   ///////////////////////////////////////// Stuff buffer with array
-  myTransfer.txObj(arr, sizeof(arr), sendSize);
-  sendSize += sizeof(arr);
+  sendSize = myTransfer.txObj(arr, sizeof(arr), sendSize);
 
   ///////////////////////////////////////// Send buffer
   myTransfer.sendData(sendSize);

--- a/examples/tx_multiple_objects/tx_multiple_objects.ino
+++ b/examples/tx_multiple_objects/tx_multiple_objects.ino
@@ -37,7 +37,7 @@ void loop()
   sendSize = myTransfer.txObj(testStruct, sendSize);
 
   ///////////////////////////////////////// Stuff buffer with array
-  sendSize = myTransfer.txObj(arr, sizeof(arr), sendSize);
+  sendSize = myTransfer.txObj(arr, sendSize);
 
   ///////////////////////////////////////// Send buffer
   myTransfer.sendData(sendSize);

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SerialTransfer
-version=2.0.3
+version=2.1.0
 author=PowerBroker2 <gitstuff2@gmail.com>
 maintainer=PowerBroker2 <gitstuff2@gmail.com>
 sentence=Arduino library to transfer packetized data fast/reliably via UART/Serial

--- a/src/SerialTransfer.h
+++ b/src/SerialTransfer.h
@@ -74,7 +74,7 @@ public: // <<---------------------------------------//public
 
 
 	/*
-	 void SerialTransfer::txObj(const T &val, const uint16_t &len=sizeof(T), const uint16_t &index=0)
+	 uint16_t SerialTransfer::txObj(const T &val, const uint16_t &index=0, const uint16_t &len=sizeof(T))
 	 Description:
 	 ------------
 	  * Stuffs "len" number of bytes of an arbitrary object (byte, int,
@@ -85,16 +85,17 @@ public: // <<---------------------------------------//public
 	 -------
 	  * const T &val - Pointer to the object to be copied to the
 	  transmit buffer (txBuff)
-	  * const uint16_t &len - Number of bytes of the object "val" to transmit
 	  * const uint16_t &index - Starting index of the object within the
 	  transmit buffer (txBuff)
+	  * const uint16_t &len - Number of bytes of the object "val" to transmit
 
 	 Return:
 	 -------
-	  * uint8_t - Number of bytes written to the transmit buffer (txBuff)
+	  * uint16_t maxIndex - uint16_t maxIndex - Index of the transmit buffer (txBuff) that directly follows the bytes processed
+	  by the calling of this member function
 	*/
 	template <typename T>
-	uint8_t txObj(const T &val, const uint16_t &len=sizeof(T), const uint16_t &index=0)
+	uint16_t txObj(const T &val, const uint16_t &index=0, const uint16_t &len=sizeof(T))
 	{
 		uint8_t* ptr = (uint8_t*)&val;
 		uint16_t maxIndex;
@@ -110,17 +111,14 @@ public: // <<---------------------------------------//public
 			ptr++;
 		}
 
-		if ((len + index) > MAX_PACKET_SIZE)
-			return MAX_PACKET_SIZE - index;
-		else
-			return len;
+		return maxIndex;
 	}
 
 
 
 
 	/*
-	 void SerialTransfer::rxObj(const T &val, const uint16_t &len=sizeof(T), const uint16_t &index=0)
+	 uint16_t SerialTransfer::rxObj(const T &val, const uint16_t &index=0, const uint16_t &len=sizeof(T))
 	 Description:
 	 ------------
 	  * Reads "len" number of bytes from the receive buffer (rxBuff)
@@ -131,16 +129,17 @@ public: // <<---------------------------------------//public
 	 -------
 	  * const T &val - Pointer to the object to be copied into from the
 	  receive buffer (rxBuff)
-	  * const uint16_t &len - Number of bytes in the object "val" received
 	  * const uint16_t &index - Starting index of the object within the
 	  receive buffer (rxBuff)
+	  * const uint16_t &len - Number of bytes in the object "val" received
 
 	 Return:
 	 -------
-	  * uint8_t - Number of bytes read from the receive buffer (rxBuff)
+	  * uint16_t maxIndex - Index of the receive buffer (rxBuff) that directly follows the bytes processed
+	  by the calling of this member function
 	*/
 	template <typename T>
-	uint8_t rxObj(const T &val, const uint16_t &len=sizeof(T), const uint16_t &index=0)
+	uint16_t rxObj(const T &val, const uint16_t &index=0, const uint16_t &len=sizeof(T))
 	{
 		uint8_t* ptr = (uint8_t*)&val;
 		uint16_t maxIndex;
@@ -156,10 +155,7 @@ public: // <<---------------------------------------//public
 			ptr++;
 		}
 
-		if ((len + index) > MAX_PACKET_SIZE)
-			return MAX_PACKET_SIZE - index;
-		else
-			return len;
+		return maxIndex;
 	}
 
 


### PR DESCRIPTION
- Switch argument order for `txObj()` and `rxObj()`
- `txObj()` and `rxObj()` now returns next buffer index instead of # of processed bytes
- Update readme/examples for above changes