### PR TITLE
Extend gate for SPITransfer include

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ See the [example sketches](https://github.com/PowerBroker2/SerialTransfer/tree/m
 
 # ***NOTE:***
 
-SPITransfer.h and it's associated features are not supported for the Arduino Nano 33 BLE or DUE.
+SPITransfer.h and it's associated features are not supported for the Arduino Nano 33 BLE or DUE and other boards. This header file is disabled by default, but can be enabled by commenting out `#define DISABLE_SPI_SERIALTRANSFER 1` within `SerialTransfer.h`.

--- a/src/SPITransfer.cpp
+++ b/src/SPITransfer.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 
-#if not(defined(MBED_H) || defined(__SAM3X8E__)) // These boards are/will not be supported by SPITransfer.h
+#if not(defined(MBED_H) || defined(__SAM3X8E__) || defined(DISABLE_SPI_SERIALTRANSFER)) // These boards are/will not be supported by SPITransfer.h
 
 #include "SPITransfer.h"
 

--- a/src/SPITransfer.h
+++ b/src/SPITransfer.h
@@ -2,7 +2,7 @@
 
 #include "Arduino.h"
 
-#if not(defined(MBED_H) || defined(__SAM3X8E__)) // These boards are/will not be supported by SPITransfer.h
+#if not(defined(MBED_H) || defined(__SAM3X8E__) || defined(DISABLE_SPI_SERIALTRANSFER)) // These boards are/will not be supported by SPITransfer.h
 
 #include "Packet.h"
 #include "SPI.h"

--- a/src/SerialTransfer.h
+++ b/src/SerialTransfer.h
@@ -3,6 +3,9 @@
 #include "Packet.h"
 
 
+#define DISABLE_SPI_SERIALTRANSFER 1 // Comment out to use SPITransfer.h
+
+
 class SerialTransfer
 {
   public: // <<---------------------------------------//public


### PR DESCRIPTION
I was also having the same problem as described in the issue, but on an STM32 board. Rather than having to add another board to the list explicitly, I've added an additional clause to the existing gate, to prevent inclusion of
`SPITransfer` if `DISABLE_SPI_SERIALTRANSFER` is set. This way I can set it as a build flag, or as a define in my own code to avoid the `SPDR` issue.