### PR TITLE
Make callbacks const-qualified. Fix invalid memory usage in callback examples.

### DIFF
--- a/examples/i2c_rx_data/i2c_rx_data.ino
+++ b/examples/i2c_rx_data/i2c_rx_data.ino
@@ -26,6 +26,9 @@ void hi()
   recSize = myTransfer.rxObj(arr, recSize);
   Serial.println(arr);
 }
+
+// supplied as a reference - persistent allocation required
+const functionPtr callbackArr[] = { hi };
 ///////////////////////////////////////////////////////////////////
 
 
@@ -33,8 +36,6 @@ void setup()
 {
   Serial.begin(115200);
   Wire.begin(0);
-
-  functionPtr callbackArr[] = { hi };
 
   ///////////////////////////////////////////////////////////////// Config Parameters
   configST myConfig;

--- a/examples/i2c_rx_datum/i2c_rx_datum.ino
+++ b/examples/i2c_rx_datum/i2c_rx_datum.ino
@@ -16,6 +16,9 @@ void hi()
   Serial.print(testStruct.z);
   Serial.println(testStruct.y);
 }
+
+// supplied as a reference - persistent allocation required
+const functionPtr callbackArr[] = { hi };
 ///////////////////////////////////////////////////////////////////
 
 
@@ -23,8 +26,6 @@ void setup()
 {
   Serial.begin(115200);
   Wire.begin(0);
-
-  functionPtr callbackArr[] = { hi };
 
   ///////////////////////////////////////////////////////////////// Config Parameters
   configST myConfig;

--- a/examples/uart_rx_with_callbacks/uart_rx_with_callbacks.ino
+++ b/examples/uart_rx_with_callbacks/uart_rx_with_callbacks.ino
@@ -9,6 +9,9 @@ void hi()
 {
   Serial.println("hi");
 }
+
+// supplied as a reference - persistent allocation required
+const functionPtr callbackArr[] = { hi };
 ///////////////////////////////////////////////////////////////////
 
 
@@ -16,8 +19,6 @@ void setup()
 {
   Serial.begin(115200);
   Serial1.begin(115200);
-
-  functionPtr callbackArr[] = { hi };
 
   ///////////////////////////////////////////////////////////////// Config Parameters
   configST myConfig;

--- a/src/Packet.h
+++ b/src/Packet.h
@@ -37,10 +37,10 @@ const uint8_t NUM_OVERHEAD    = 6;    // Delete
 
 struct configST
 {
-	Stream*      debugPort    = &Serial;
-	bool         debug        = true;
-	functionPtr* callbacks    = NULL;
-	uint8_t      callbacksLen = 0;
+	Stream*            debugPort    = &Serial;
+	bool               debug        = true;
+	const functionPtr* callbacks    = NULL;
+	uint8_t            callbacksLen = 0;
 };
 
 
@@ -160,8 +160,8 @@ class Packet
 	};
 	fsm state = find_start_byte;
 
-	functionPtr* callbacks    = NULL;
-	uint8_t      callbacksLen = 0;
+	const functionPtr* callbacks    = NULL;
+	uint8_t            callbacksLen = 0;
 
 	Stream* debugPort;
 	bool    debug = false;


### PR DESCRIPTION
Fix #42