### PR TITLE
Fix compiler warnings about signed-to-unsigned comparison.

### DIFF
--- a/src/PacketCRC.h
+++ b/src/PacketCRC.h
@@ -20,7 +20,7 @@ class PacketCRC
 
 	void generateTable()
 	{
-		for (int i = 0; i < tableLen_; ++i)
+		for (uint16_t i = 0; i < tableLen_; ++i)
 		{
 			int curr = i;
 
@@ -38,7 +38,7 @@ class PacketCRC
 
 	void printTable()
 	{
-		for (int i = 0; i < tableLen_; i++)
+		for (uint16_t i = 0; i < tableLen_; i++)
 		{
 			Serial.print(csTable[i], HEX);
 


### PR DESCRIPTION
Fixes the warnings below, which made the compiler fail with `-Werror`.

```
.pio/libdeps/ATmega328P/SerialTransfer/src/PacketCRC.h: In member function 'void PacketCRC::generateTable()':
.pio/libdeps/ATmega328P/SerialTransfer/src/PacketCRC.h:23:21: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   for (int i = 0; i < tableLen_; ++i)
                     ^
.pio/libdeps/ATmega328P/SerialTransfer/src/PacketCRC.h: In member function 'void PacketCRC::printTable()':
.pio/libdeps/ATmega328P/SerialTransfer/src/PacketCRC.h:41:21: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   for (int i = 0; i < tableLen_; i++)
```
